### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/Chapter Five/Chapter 5 - Liking Larry's Legs.md
+++ b/Chapter Five/Chapter 5 - Liking Larry's Legs.md
@@ -1,4 +1,4 @@
-#Chapter 5 - Liking Larry's Legs
+# Chapter 5 - Liking Larry's Legs
 
 
 
@@ -465,17 +465,17 @@ body {
   }
 }
 
-#image-preview {
+# image-preview {
   margin: 0 auto;
 }
 
-#post_image {
+# post_image {
   padding: 1em;
   margin: 0px auto;
 }
 
 
-#paginator {
+# paginator {
   color: #4090DB;
   height: 120px;
   width: 120px;
@@ -490,7 +490,7 @@ body {
   }
 }
 
-#load_more {
+# load_more {
   display: table-cell;
   font-size: 12px;
   padding: 0px 9px;
@@ -543,11 +543,11 @@ body {
   margin-top: 20px;
 }
 
-#user_bio {
+# user_bio {
   border: 1px solid gray;
 }
 
-#user_avatar {
+# user_avatar {
   padding: 1em;
   margin: 0px auto;
 }
@@ -577,7 +577,7 @@ Now, let’s discuss what we need to build next:
 But fear not, brave reader!  We will be solving these issues and much, much more (well, maybe not too much) now!
 
 
-##Solid Red, An Ego Fed
+## Solid Red, An Ego Fed
 
 Let’s start small, let’s make sure that the heart turns solid red upon successfully liking Larry’s legs.  In Step One of this feature, we made sure that clicking the button does in fact 'like' the post, the problem is that it doesn’t actually show it.  The 'like' action in the PostsController can return javascript thanks to this code:
 ```ruby

--- a/Chapter Five/Chapter 5 - Liking Larry's Legs.md
+++ b/Chapter Five/Chapter 5 - Liking Larry's Legs.md
@@ -465,17 +465,17 @@ body {
   }
 }
 
-# image-preview {
+#image-preview {
   margin: 0 auto;
 }
 
-# post_image {
+#post_image {
   padding: 1em;
   margin: 0px auto;
 }
 
 
-# paginator {
+#paginator {
   color: #4090DB;
   height: 120px;
   width: 120px;
@@ -490,7 +490,7 @@ body {
   }
 }
 
-# load_more {
+#load_more {
   display: table-cell;
   font-size: 12px;
   padding: 0px 9px;
@@ -543,11 +543,11 @@ body {
   margin-top: 20px;
 }
 
-# user_bio {
+#user_bio {
   border: 1px solid gray;
 }
 
-# user_avatar {
+#user_avatar {
   padding: 1em;
   margin: 0px auto;
 }

--- a/Chapter Four/Chapter 4 - Presenting Pretty Profile.md
+++ b/Chapter Four/Chapter 4 - Presenting Pretty Profile.md
@@ -14,7 +14,7 @@ Let's begin.... meow.
 
 
 
-##An Explanation of the Feature
+## An Explanation of the Feature
 
 Let's think about what a profile page is, in order to flesh out the features.  We want to have:
 
@@ -136,7 +136,7 @@ Give yourself or a nearby human a high five to celebrate.
 
 
 
-##Expressing Egos with Elegant Essays
+## Expressing Egos with Elegant Essays
 
 It's bio and profile picture time!  If you want a refresher on the features we're building here, go back up to the test section and have a quick scan.  If a profile page belongs to us, we want to be able to click an 'Edit Profile' link and there, have the ability to change our profile picture or our bio, save the info and be redirected back to our profile to be greeted with our new information.
 
@@ -252,7 +252,7 @@ Not too tricky to comprehend, right?  We have two rows for our form, where we re
 We have our form basics, let’s quickly add a few lines of css to our ```app/assets/stylesheets/application.scss``` file:
 
 ```language-scss
-#user_avatar {
+# user_avatar {
   margin: 20px auto;
 }
 ```
@@ -566,7 +566,7 @@ ___
 It’s super easy!  First, let’s take care of linking up the user names shown in comments.  Jump into your comment partial file at ```app/views/comments/_comment.html.haml```.  Adjust the dynamic user name line, so it looks like the third line shown below:
 
 ```ruby
-#comment
+# comment
   .user-name
     = link_to comment.user.user_name, profile_path(comment.user.user_name)
 ```

--- a/Chapter Four/Chapter 4 - Presenting Pretty Profile.md
+++ b/Chapter Four/Chapter 4 - Presenting Pretty Profile.md
@@ -252,7 +252,7 @@ Not too tricky to comprehend, right?  We have two rows for our form, where we re
 We have our form basics, let’s quickly add a few lines of css to our ```app/assets/stylesheets/application.scss``` file:
 
 ```language-scss
-# user_avatar {
+#user_avatar {
   margin: 20px auto;
 }
 ```
@@ -566,7 +566,7 @@ ___
 It’s super easy!  First, let’s take care of linking up the user names shown in comments.  Jump into your comment partial file at ```app/views/comments/_comment.html.haml```.  Adjust the dynamic user name line, so it looks like the third line shown below:
 
 ```ruby
-# comment
+#comment
   .user-name
     = link_to comment.user.user_name, profile_path(comment.user.user_name)
 ```

--- a/Chapter One/Chapter One.md
+++ b/Chapter One/Chapter One.md
@@ -1,4 +1,4 @@
-#Chapter One - Just CRUD Things
+# Chapter One - Just CRUD Things
 
 
 
@@ -61,7 +61,7 @@ You should see this screen as a friendly reminder that you’re awesome:
 
 You are by the way ;)
 
-###Back to the build, you fiend!
+### Back to the build, you fiend!
  Let’s start building our application.  Remember, the TDD version of this free book is coming and I don't want you to risk being too incredible just now.  That and I want you to have a great foundation from which to learn to test.
 
 Let's be cowboy devs for the moment.
@@ -147,7 +147,7 @@ We’ll get back to actually having something of value in our index but for the 
 
 
 
-###First, a database!
+### First, a database!
 
 We’re going to need to generate a model in terminal to store our posts, including caption and image.  Let’s create the model “post” with only a string column for “caption”.  We’ll add the image functionality in a moment.
 
@@ -239,7 +239,7 @@ We can now officially handle image uploads! Give yourself a high ten and forge o
 
 
 
-###Out with the old in with the new action
+### Out with the old in with the new action
 
 Create a new empty action in your ```posts_controller.rb``` file called ‘new’, exactly the same as you did earlier with the index action.  
 
@@ -435,7 +435,7 @@ What an incredible achievement.  It’s not super functional yet though, I can�
 
 Being able to show individual posts would be nice too but that can all wait because I’m sick of this thing looking awful.
 
-###Styling: Let’s steal like an artist or something
+### Styling: Let’s steal like an artist or something
 
  Let’s blatantly steal from Instagram, for this is an Instagram clone tutorial after all!  
 
@@ -626,7 +626,7 @@ Let’s keep building the apps functionality now.
 
 
 
-###Show me a single post you silly application!
+### Show me a single post you silly application!
 
 Hey, you talk to Photogram nicely please.
 
@@ -692,7 +692,7 @@ Now you should have the ability to click one of your posts on the index and it s
 
 
 
-###Let me edit my posts, I’ve made a horrible mistake
+### Let me edit my posts, I’ve made a horrible mistake
 
 We all make mistakes but at least we can fix this one for you.  Take a moment and have a think about what we’re going to need to do to implement this.  In fact, you’ve probably done this before in your previous applications!
 
@@ -824,7 +824,7 @@ And it’s done!  Try deleting one of your pics now and see what happens.
 
 
 
-##Tidy, tidy, tidy
+## Tidy, tidy, tidy
 
 Basic functionality has been created, let’s clean up a little before we finish for the moment.
 
@@ -990,7 +990,7 @@ flash[:alert] = “Oh god something is wrong”
 
 
 
-###CRUD Complete
+### CRUD Complete
 
 You have now created a great CRUD application that looks pretty snazzy, but we’re still missing a few things I’d like to see.  Users with authentication, comments and likes to be specific.  Maybe even a profile page for each user.
 

--- a/Chapter Seven/Chapter 7 - Following Fancy Friends.md
+++ b/Chapter Seven/Chapter 7 - Following Fancy Friends.md
@@ -468,10 +468,10 @@ ___
 Create a new partial view called ```_post_dashboard.html.haml```.  Copy over all your haml from your index view into the new view.
 
 ```ruby
-# posts
+#posts
   = render 'posts'
 
-# paginator.text-center
+#paginator.text-center
   = link_to_next_page @posts, 'LOAD MORE', remote: true, id: 'load_more'
 ```
 

--- a/Chapter Seven/Chapter 7 - Following Fancy Friends.md
+++ b/Chapter Seven/Chapter 7 - Following Fancy Friends.md
@@ -1,4 +1,4 @@
-#Chapter 7 - Following Fancy Friends
+# Chapter 7 - Following Fancy Friends
 
 
 
@@ -468,10 +468,10 @@ ___
 Create a new partial view called ```_post_dashboard.html.haml```.  Copy over all your haml from your index view into the new view.
 
 ```ruby
-#posts
+# posts
   = render 'posts'
 
-#paginator.text-center
+# paginator.text-center
   = link_to_next_page @posts, 'LOAD MORE', remote: true, id: 'load_more'
 ```
 

--- a/Chapter Six/Chapter 6 - Ninety Nine Nice Notifications.md
+++ b/Chapter Six/Chapter 6 - Ninety Nine Nice Notifications.md
@@ -1,4 +1,4 @@
-#Chapter 6 - Ninety Nine Nice Notifications
+# Chapter 6 - Ninety Nine Nice Notifications
 
 
 

--- a/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
+++ b/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
@@ -1,4 +1,4 @@
-#Chapter 3 - Fabulous Forms & Pleasant Pagination
+# Chapter 3 - Fabulous Forms & Pleasant Pagination
 
 
 
@@ -49,7 +49,7 @@ How great do those forms look now? It's ok, you don't have to tell me, they look
 
 
 
-##Sign Me Up to This Glorious Looking Site
+## Sign Me Up to This Glorious Looking Site
 
 Let's first attack our registration form, it is the form our users will see first after all.  To begin, let's make some simple styling choices and implement them with our bootstrap divs and some simple CSS.
 
@@ -168,7 +168,7 @@ Open the registration form now in your browser and submit some crappy informatio
 
 
 
-##Logging in should feel like a win
+## Logging in should feel like a win
 
 You've already built one beautiful form, go ahead and try to build this one now.  Use the exact same principles and heck, the same divs and css.  let's not be wasteful here.  Here's the new and improved login form again for reference:
 
@@ -224,7 +224,7 @@ Look good?  You bet your ass it does.  Now, onto...
 
 
 
-##Pretty Post Posting & Previews
+## Pretty Post Posting & Previews
 
 Our old form looks a bit yuck and we don't get to preview our images either!  It's just not right.  let's shake things up a bit so our form actually looks OK, and we can have a quick glimpse at our image before we post, just in case we were to accidentally upload a picture of our glutes again...
 
@@ -285,11 +285,11 @@ I really love this, because of it's sheer simplicity.  It achieves what we want,
 Here's some extra styling you can add to your ```application.scss``` file too:
 
 ```scss
-#image-preview {
+# image-preview {
   margin: 0px auto;
 }
 
-#post_image {
+# post_image {
   padding: 1em;
   margin: 0px auto;
 }
@@ -460,10 +460,10 @@ ___
 Here's how I implemented this feature, manual clicking style.  First, I slightly adjusted the index view and added a new partial (for the sake of AJAX).  Here's my updated ```index.html.haml```:
 
 ```ruby
-#posts
+# posts
   = render 'posts'
 
-#paginator.text-center
+# paginator.text-center
   = link_to_next_page @posts, 'LOAD MORE', remote: true, id: 'load_more'
 ```
 
@@ -472,7 +472,7 @@ Differences?  We'll I've got a new div with the 'posts' id.  Also, instead of it
 Speaking of styling, below is the the additional lines in my ```application.scss``` file.  Just add them to the bottom of your existing code.
 
 ```scss
-#paginator {
+# paginator {
   color: #4090DB;
   height: 120px;
   width: 120px;
@@ -487,7 +487,7 @@ Speaking of styling, below is the the additional lines in my ```application.scss
   }
 }
 
-#load_more {
+# load_more {
   display: table-cell;
   font-size: 12px;
   padding: 0px 9px;
@@ -699,7 +699,7 @@ Quite simple, we simply render the ```_comment.html.haml``` partial for each com
 Now, here's the last piece of the puzzle, our unchanged ```views/comments/_comment.html.haml``` partial.
 
 ```ruby
-#comment
+# comment
   .user-name
     = comment.user.user_name
   .comment-content

--- a/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
+++ b/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
@@ -285,11 +285,11 @@ I really love this, because of it's sheer simplicity.  It achieves what we want,
 Here's some extra styling you can add to your ```application.scss``` file too:
 
 ```scss
-# image-preview {
+#image-preview {
   margin: 0px auto;
 }
 
-# post_image {
+#post_image {
   padding: 1em;
   margin: 0px auto;
 }

--- a/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
+++ b/Chapter Three/Chapter 3 - Fabulous Forms & Pleasant Pagination.md
@@ -460,10 +460,10 @@ ___
 Here's how I implemented this feature, manual clicking style.  First, I slightly adjusted the index view and added a new partial (for the sake of AJAX).  Here's my updated ```index.html.haml```:
 
 ```ruby
-# posts
+#posts
   = render 'posts'
 
-# paginator.text-center
+#paginator.text-center
   = link_to_next_page @posts, 'LOAD MORE', remote: true, id: 'load_more'
 ```
 
@@ -472,7 +472,7 @@ Differences?  We'll I've got a new div with the 'posts' id.  Also, instead of it
 Speaking of styling, below is the the additional lines in my ```application.scss``` file.  Just add them to the bottom of your existing code.
 
 ```scss
-# paginator {
+#paginator {
   color: #4090DB;
   height: 120px;
   width: 120px;
@@ -487,7 +487,7 @@ Speaking of styling, below is the the additional lines in my ```application.scss
   }
 }
 
-# load_more {
+#load_more {
   display: table-cell;
   font-size: 12px;
   padding: 0px 9px;
@@ -699,7 +699,7 @@ Quite simple, we simply render the ```_comment.html.haml``` partial for each com
 Now, here's the last piece of the puzzle, our unchanged ```views/comments/_comment.html.haml``` partial.
 
 ```ruby
-# comment
+#comment
   .user-name
     = comment.user.user_name
   .comment-content

--- a/Chapter Two/Chapter Two.md
+++ b/Chapter Two/Chapter Two.md
@@ -1,4 +1,4 @@
-#Chapter 2 - Log In & Tell Me I'm Beautiful
+# Chapter 2 - Log In & Tell Me I'm Beautiful
 
 
 
@@ -1082,7 +1082,7 @@ Well, we want to re-render the comments of an individual post once our *new* com
 The comment partial is shown below.  Call it ```_comment.html.haml``` and create it in the ```views/comments``` folder.
 
 ```language-ruby
-#comment
+# comment
   .user-name
     = comment.user.user_name
   .comment-content
@@ -1218,7 +1218,7 @@ Here’s how I implemented AJAX into the deletion of comments.
 This time we’re adding it to the destroy form, not the create form (you can find the form for the destroy action in the ```_comment.html.haml``` partial view).  Check out my version below:
 
 ```language-ruby
-#comment
+# comment
   .user-name
     = comment.user.user_name
   .comment-content

--- a/Chapter Two/Chapter Two.md
+++ b/Chapter Two/Chapter Two.md
@@ -1082,7 +1082,7 @@ Well, we want to re-render the comments of an individual post once our *new* com
 The comment partial is shown below.  Call it ```_comment.html.haml``` and create it in the ```views/comments``` folder.
 
 ```language-ruby
-# comment
+#comment
   .user-name
     = comment.user.user_name
   .comment-content
@@ -1218,7 +1218,7 @@ Here’s how I implemented AJAX into the deletion of comments.
 This time we’re adding it to the destroy form, not the create form (you can find the form for the destroy action in the ```_comment.html.haml``` partial view).  Check out my version below:
 
 ```language-ruby
-# comment
+#comment
   .user-name
     = comment.user.user_name
   .comment-content

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-#Let's Build Instagram With Ruby on Rails - Free Edition
+# Let's Build Instagram With Ruby on Rails - Free Edition
 
 
 
@@ -8,7 +8,7 @@ It's great to have you here.  The above repo is all of the markdown files & imag
 
 
 
-##Why's it here?
+## Why's it here?
 
 Well, the book isn't… perfect.  There are some typos and little errors that are rustling some jimmies.  PR's are more than welcome!
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
